### PR TITLE
fix 1 lgtm.com error

### DIFF
--- a/src/core/requests/tor.py
+++ b/src/core/requests/tor.py
@@ -66,12 +66,7 @@ def do_check():
     except urllib2.URLError, err_msg:
       print "[" + Fore.RED + " FAILED " + Style.RESET_ALL + "]"
       print settings.print_critical_msg(err_msg)
-      sys.exit(0)
-      
-    except urllib2.HTTPError, err_msg:
-      print "[" + Fore.RED + " FAILED " + Style.RESET_ALL + "]"
-      print settings.print_critical_msg(err_msg)
-      sys.exit(0)
+      sys.exit(0)  
 
 """
 Use the TOR HTTP Proxy.


### PR DESCRIPTION
Hi,
Just wanted to quickly fix this alert flagged up on lgtm.com.

`HTTPError` is a subclass of `URLError` so the ordering of the except blocks would have never allowed to reach it.
If a different action should be taken for `HTTPError` then its block should be moved before that of `URLError` - otherwise, as it seemed to be case, it can just be deleted.

Hope this helps!

A total of 317 alerts have been flagged up by lgtm.com, you can enable pull request integration for fully automated PR reviews that will flag these in the future so that they don't get past code review.
https://lgtm.com/projects/g/stasinopoulos/commix/