### PR TITLE
docs: fix simple typo, mutiple -> multiple

### DIFF
--- a/src/core/injections/controller/parser.py
+++ b/src/core/injections/controller/parser.py
@@ -30,7 +30,7 @@ Parse target and data from http proxy logs (i.e Burp or WebScarab)
 """
 def logfile_parser():
   """
-  Warning message for mutiple request in same log file.
+  Warning message for multiple request in same log file.
   """
   def multi_requests():
     print(settings.SUCCESS_STATUS)


### PR DESCRIPTION
There is a small typo in src/core/injections/controller/parser.py.

Should read `multiple` rather than `mutiple`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md