### PR TITLE
fix do_GET_check

### DIFF
--- a/src/core/requests/parameters.py
+++ b/src/core/requests/parameters.py
@@ -55,7 +55,7 @@ def do_GET_check(url):
         raise SystemExit()
     elif menu.options.shellshock:
       return False
-    return url
+    return [url]
 
   else:
     urls_list = []


### PR DESCRIPTION
In this case "do_GET_check" returns string instead of []str. It cause "ValueError: unknown url type: '://h'" if url does not contain GET params. 
For example do_GET_check("http://xx.xx.xx.xx:xxxx/*") return "http://xx.xx.xx.xx:xxxx/INJECT_HERE" instead of  ["http://xx.xx.xx.xx:xxxx/INJECT_HERE"]. Then, in for loops in controller.py:463 url = 'h'