### PR TITLE
Fix typo 'ptint' instead of 'print'

### DIFF
--- a/src/core/injections/controller/checks.py
+++ b/src/core/injections/controller/checks.py
@@ -2092,7 +2092,7 @@ def print_users(sys_users, filename, _, separator, TAG, cmd, prefix, suffix, whi
         # print(settings.SINGLE_WHITESPACE)
         warn_msg = "It seems that you don't have permissions to read the '" 
         warn_msg += settings.PASSWD_FILE + "'."
-        ptint(settings.print_warning_msg(warn_msg))  
+        print(settings.print_warning_msg(warn_msg))  
     except TypeError:
       pass
     except IndexError:


### PR DESCRIPTION
I've already pushed the patch in Kali so it should be fixed soon https://gitlab.com/kalilinux/packages/commix/-/commit/799c72b4698bcdaeb4c3cd5b3dc66254acf57438