### PR TITLE
Update parser.py

### DIFF
--- a/src/core/injections/controller/parser.py
+++ b/src/core/injections/controller/parser.py
@@ -124,7 +124,7 @@ def logfile_parser():
   scheme = "http://"
 
   for line in request_headers:
-    if re.findall(r"" + settings.HOST + ":" + " (.*)", line):
+    if re.findall(r"^" + settings.HOST + ":" + " (.*)", line):
       menu.options.host = "".join([str(i) for i in re.findall(r"" + settings.HOST + ":" + " (.*)", line)])
     # User-Agent Header
     if re.findall(r"" + settings.USER_AGENT + ":" + " (.*)", line):


### PR DESCRIPTION
If commix is used with a file and -r and a host header like "X-Forwarded-Host:" is set, commix took this host as target. Therefore i added a "^" so that "Host" has to be at the beginning of the line. Therefore only "Host:" is chosen as a target an not headers like "X-Forwarded-For".

Feel free to reject if the fix doesn't meet your style or is garbage :-).