### PR TITLE
Fixes missing shocker-cgi_list.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
       license='GNU General Public License v3 (GPLv3)',
       packages=find_packages(),
       include_package_data=True,
+      package_data={"": ["*.txt"]},
       zip_safe=False,
     classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This patch should make `shocker-cgi_list.txt` available during runtime.
* https://github.com/commixproject/commix/issues/547
* https://github.com/commixproject/commix/issues/549 
* https://github.com/commixproject/commix/issues/825



While testing Commix on a burp lab, I came across this error.

![shocker_cgi_list_missing](https://github.com/user-attachments/assets/db6c7f27-eb43-4756-971b-271d7b60f7ac)


Alternatively, we could create a `MANIFEST.in`, but that seems a bit overkill.
https://setuptools.pypa.io/en/latest/userguide/datafiles.html