### PR TITLE
fix: improve resource management for file handle and HTTP response handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,14 @@ For more see the file 'readme/COPYING' for copying permission.
 
 from setuptools import setup, find_packages
 
+with open('README.md', 'r', encoding='utf-8') as f:
+    long_description = f.read()
+
 setup(
       name='commix',
       version='4.2.dev',
       description='Automated All-in-One OS Command Injection Exploitation Tool',
-      long_description=open('README.md').read(),
+      long_description=long_description,
       long_description_content_type='text/markdown',
       author='Anastasios Stasinopoulos',
       url='https://commixproject.com',

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -210,7 +210,9 @@ def create_github_issue(err_msg, exc_msg):
   )
 
   try:
-    content = _urllib.request.urlopen(request, timeout=settings.TIMEOUT).read()
+    response = _urllib.request.urlopen(request, timeout=settings.TIMEOUT)
+    content = response.read()
+    response.close()
     _ = json.loads(content)
 
     duplicate = _["total_count"] > 0


### PR DESCRIPTION
## Description

This PR improves resource management in file handle and HTTP response handling:

1. **setup.py**: Replaced bare \open(...).read()\ with a \with\ statement to ensure the file handle is always closed, including on exceptions.
2. **src/utils/common.py**: \create_github_issue()\ now stores the \urlopen\ response object, reads its content, and explicitly closes it after use. The \content\ variable is preserved for callers.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tested with Python 3.11 on Windows 11:
- Verified \setup.py\ can read README.md correctly
- Verified HTTP response is properly closed after reading
- No \ResourceWarning\ messages during execution

## Impact

- \setup.py\: Context manager (\with\ statement, PEP 343) ensures proper cleanup of README file handle.
- \src/utils/common.py\: HTTP response is explicitly closed after reading (not via context manager, since \urlopen\ returns a single response and we explicitly close it after extracting the bytes).

These are resource management improvements — the previous code was generally cleaned up by Python's garbage collector, but explicit cleanup is more robust and avoids relying on GC timing.